### PR TITLE
tsc以外のtypescriptトランスパイラを使う場合に設定するとよい話について

### DIFF
--- a/articles/df3b023178df80.md
+++ b/articles/df3b023178df80.md
@@ -1,9 +1,9 @@
 ---
 title: "TypeScript Compilerにファイルを出力させない方法"
-emoji: "📝"
+emoji: "👻"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: [typescript]
-published: false
+published: true
 ---
 
 TypeScript Compiler (TSC) のコンパイルオプションに、ファイルを生成しないオプションがある。

--- a/articles/df3b023178df80.md
+++ b/articles/df3b023178df80.md
@@ -1,0 +1,21 @@
+---
+title: "TypeScript Compilerにファイルを出力させない方法"
+emoji: "📝"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [typescript]
+published: false
+---
+
+TypeScript Compiler (TSC) のコンパイルオプションに、ファイルを生成しないオプションがある。
+
+```sh
+tsc --noEmit
+```
+
+TSC にファイル出力をさせないことで、バンドラーツールにファイル出力させる余地を作る。
+これにより、TSCを型チェッカーとして運用できる。
+
+## References
+
+- [TypeScript: Documentation - tsc CLI Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)
+- [TypeScript: TSConfig Reference - Docs on every TSConfig option](https://www.typescriptlang.org/tsconfig/#noEmit)

--- a/articles/e851613aacc4eb.md
+++ b/articles/e851613aacc4eb.md
@@ -1,0 +1,66 @@
+---
+title: "TypeScript Compiler の isolatedModules オプションとは"
+emoji: "📦"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [typescript]
+published: false
+---
+
+TypeScript のコードを扱うにあたって、 TypeScript Compiler (TSC) 以外のトランスパイラに配慮するためのものである。
+
+TSC 以外のトランスパイラは、往々にして一度にひとつのファイルのみ扱うので、完全な型システムの理解はない。
+このため、`const enum` や `namespace` を正しく扱えない可能性がある。
+
+`isolatedModules` オプションを有効にすると、シングルファイルでの変換で正しく扱えない可能性のあるコードについて、警告を出す。
+
+## フラグが有効のときに使えないコード
+
+### 値のない型の export
+
+TSC では、ある型が実態のない（型情報しかない）場合、javaScriptでは `export` の対象から省く。
+
+```ts:example1.ts
+import { someType, someFunction } from "someModule";
+
+someFunction();
+
+export { someType, someFunction };
+```
+
+```js:example1.js
+export { someFunction };
+```
+
+トランスパイラは型が値を生成するか判断できない。よって、型のみを `export` するとエラーとする。
+
+### モジュールじゃないコード
+
+```ts:example2.ts
+function fn() {}
+```
+
+すべてのコードをモジュールにすることが求められるので、何らかの `import` / `export` をするか、空の `export` を埋め込む必要がある。
+
+### `const enum` を使っているコード
+
+```ts:example3.ts
+declare const enum Numbers {
+    Zero = 0,
+    One = 1,
+}
+console.log(Numbers.Zero + Numbers.One);
+```
+
+これは、変換後に実際の値へ置き換えられる。
+
+```js:example3.js
+"use strict";
+console.log(0 + 1);
+```
+
+シングルファイルのトランスパイルでは、このように(特に他のァイルで定義されたconstなどの)参照を置き換えられない。
+よって、エラーとさせる。
+
+## References
+
+- [TypeScript: TSConfig Reference - Docs on every TSConfig option](https://www.typescriptlang.org/tsconfig#isolatedModules)

--- a/articles/e851613aacc4eb.md
+++ b/articles/e851613aacc4eb.md
@@ -3,7 +3,7 @@ title: "TypeScript Compiler の isolatedModules オプションとは"
 emoji: "📦"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: [typescript]
-published: false
+published: true
 ---
 
 TypeScript のコードを扱うにあたって、 TypeScript Compiler (TSC) 以外のトランスパイラに配慮するためのものである。


### PR DESCRIPTION
obsidian pluginのテンプレートリポジトリの変更をキャッチアップしていたら、 TSC以外のトランスパイラを使うときに使用すると良い設定について述べられていたので、確認したことを記事にした。

https://github.com/obsidianmd/obsidian-sample-plugin/pull/22